### PR TITLE
Get rustc version in project context

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -139,7 +139,7 @@ class RustProjectSettingsPanel(
                 val toolchain = pathToToolchain?.let { RsToolchainProvider.getToolchain(it) }
                 val rustc = toolchain?.rustc()
                 val rustup = toolchain?.rustup
-                val rustcVersion = rustc?.queryVersion()?.semver
+                val rustcVersion = rustc?.queryVersion(cargoProjectDir)?.semver
                 val stdlibLocation = rustc?.getStdlibFromSysroot(cargoProjectDir)?.presentableUrl
                 Triple(rustcVersion, stdlibLocation, rustup != null)
             },


### PR DESCRIPTION
`rustup` determines which toolchain to use from a `rust-toolchain.toml` or `rust-toolchain` file in the project’s directory if it exists.

See: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
