### PR TITLE
Remove Kotlin plugin workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,3 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 # But we don't need it because all necessary kotlin libraries are already bundled into IDE.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for more details
 kotlin.stdlib.default.dependency=false
-# Since kotlin 1.8.20, Gradle Kotlin plugin may produce OOM during compilation
-# See https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#incremental-compilation
-# and https://youtrack.jetbrains.com/issue/KT-57757 for more details
-kotlin.incremental.useClasspathSnapshot=false


### PR DESCRIPTION
Kotlin 1.9.0 and later are not affected by this issue.
