### PR TITLE
RUST-12718 Deduplicate trait bounds in LazyParamEnv.boundsFor()

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -236,7 +236,7 @@ class LazyParamEnv(private val parentItem: RsGenericDeclaration) : ParamEnv {
                 it.bound?.traitRef?.resolveToBoundTrait()
             }
             @Suppress("DEPRECATION")
-            ty.getTraitBoundsTransitively().asSequence() + additionalBounds
+            (ty.getTraitBoundsTransitively().asSequence() + additionalBounds).distinct()
         } else {
             emptySequence()
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1804,6 +1804,33 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ Bar
     """)
 
+    fun `test associated type bound with multiple child traits sharing parent`() = testExpr("""
+        trait Parent {
+            type Item;
+        }
+        trait Child1: Parent {}
+        trait Child2: Parent {}
+
+        trait Bound<A> {}
+        struct S;
+        struct X;
+
+        impl Bound<i32> for S {}
+        impl Parent for X { type Item = S; }
+        impl Child1 for X {}
+        impl Child2 for X {}
+
+        fn foo<T, U>(t: T) -> U
+            where T: Child1 + Child2,
+                  T::Item: Bound<U>,
+        { unimplemented!() }
+
+        fn main() {
+            let a = foo(X);
+            a;
+        } //^ i32
+    """)
+
     fun `test generic associated type binding in 'impl Trait' 1`() = testExpr("""
         trait Tr {
             type Item<A>;


### PR DESCRIPTION
Fix super traits associated type being resolved multiple times when a type parameter has bounds on multiple traits that share a common super trait.
