### PR TITLE
[abandoned] CI: Restore OLD_RUST_VERSION to 1.56.0

### DIFF
--- a/.github/workflows/get-rust-versions.yml
+++ b/.github/workflows/get-rust-versions.yml
@@ -20,7 +20,7 @@ on:
 env:
     STABLE: "1.94.1"
     NIGHTLY: "nightly-2025-11-15"
-    OLD: "1.82.0"
+    OLD: "1.56.0"
 
 jobs:
     get_versions:


### PR DESCRIPTION
This reverts commit 8c25a8c1427120d9df0c698e40e2110ed8606022.
